### PR TITLE
Determine if app is run by haxelib instead of assuming it always is

### DIFF
--- a/src/massive/mlib/Mlib.hx
+++ b/src/massive/mlib/Mlib.hx
@@ -49,7 +49,7 @@ import massive.mlib.cmd.PreProcessHxmlCommand;
 
 class Mlib extends CommandLineRunner
 {
-	static public function main():Mlib{return new Mlib();}
+	static public function main():Void{ new Mlib(); }
 	
 	private var settings:MlibSettings;
 	private var haxelib:Haxelib;

--- a/src/massive/sys/cmd/CommandLineRunner.hx
+++ b/src/massive/sys/cmd/CommandLineRunner.hx
@@ -60,7 +60,8 @@ class CommandLineRunner
 	
 	private function createConsole():Console
 	{
-		return new Console(true);
+		var isHaxelibRun = Sys.getEnv('HAXELIB_RUN') != null;
+		return new Console(isHaxelibRun);
 	}
 	
 	private function set_console(value:Console):Console

--- a/src/massive/sys/haxelib/Haxelib.hx
+++ b/src/massive/sys/haxelib/Haxelib.hx
@@ -46,7 +46,7 @@ class Haxelib
 	public static inline var PATCH:String = "patch";
 	public static inline var BUILD:String = "build";
 
-	public var file(default, set_file):File;
+	public var file(default, set):File;
 
 	public var name(default, set):String;
 	public var url:String;


### PR DESCRIPTION
When you run compiled app not from haxelib (like during some development or testing) there is a bug when mlib losts the last passed argument. E.g. passing these three args with `neko run.n foo bar .` seen by mlib like `foo bar` (without the last dot). This happens in `Console.hx` 

https://github.com/massive-oss/mlib/blob/98886858e701a47290d0f609f51b870b2fd15ccc/src/massive/sys/cmd/Console.hx#L209-L213

because it is always told it is a haxelib run.